### PR TITLE
Support 1st order conservative in make_remap_weights

### DIFF
--- a/tools/make_remap_weights.py
+++ b/tools/make_remap_weights.py
@@ -158,14 +158,14 @@ def main():
                         Ocean grid to regrid to, can be one of:
                         MOM1, MOM01, MOM025""")
     parser.add_argument('--method', default=None, help="""
-                        The interpolation method to use, can be patch or conserve2nd""")
+                        The interpolation method to use, can be patch, conserve or conserve2nd""")
     parser.add_argument('--npes', default=None, help="""
                         The number of PEs to use.""")
 
     args = parser.parse_args()
     atm_options = ['JRA55', 'JRA55_runoff', 'CORE2', 'Daitren_runoff']
     ocean_options = ['MOM1', 'MOM025', 'MOM01']
-    method_options = ['patch', 'conserve2nd']
+    method_options = ['patch', 'conserve', 'conserve2nd']
 
     if args.atm is None:
         args.atm = atm_options

--- a/tools/make_remap_weights.sh
+++ b/tools/make_remap_weights.sh
@@ -4,7 +4,18 @@
 #PBS -l ncpus=256,mem=512GB,walltime=05:00:00,jobfs=100GB
 #PBS -l wd
 
+module purge
+module load openmpi
+module load nco
 module load esmf/7.1.0r-intel
+module use /g/data3/hh5/public/modules
+module load conda/analysis3
+
+# Make all 1 deg weights.
+time ./make_remap_weights.py /short/x77/nah599/access-om2/input/ /g/data1/ua8/JRA55-do/RYF/v1-3/ /short/x77/nah599/access-om2/input/yatm_1deg/ --ocean MOM1 --npes 256
+
+# Make all 0.25 deg weights.
+time ./make_remap_weights.py /short/x77/nah599/access-om2/input/ /g/data1/ua8/JRA55-do/RYF/v1-3/ /short/x77/nah599/access-om2/input/yatm_1deg/ --ocean MOM025 --npes 256
 
 # Make all 0.1 deg weights.
 time ./make_remap_weights.py /short/x77/nah599/access-om2/input/ /g/data1/ua8/JRA55-do/RYF/v1-3/ /short/x77/nah599/access-om2/input/yatm_1deg/ --ocean MOM01 --npes 256

--- a/tools/make_remap_weights.sh
+++ b/tools/make_remap_weights.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #PBS -P x77
 #PBS -q normal
-#PBS -l ncpus=256,mem=512,walltime=05:00:00,jobfs=100GB
+#PBS -l ncpus=256,mem=512GB,walltime=05:00:00,jobfs=100GB
 #PBS -l wd
 
 module load esmf/7.1.0r-intel


### PR DESCRIPTION
make_remap_weights.py apparently only supports patch and conserve2nd, but we should also support conserve (1st-order conservative) as discussed here: https://github.com/COSIMA/access-om2/issues/71
