### PR TITLE
Added --unmask_dest option to make_remap_weights.py tool

### DIFF
--- a/tools/make_remap_weights.py
+++ b/tools/make_remap_weights.py
@@ -161,6 +161,9 @@ def main():
                         The interpolation method to use, can be patch or conserve2nd""")
     parser.add_argument('--npes', default=None, help="""
                         The number of PEs to use.""")
+    parser.add_argument('--unmask_dest', 
+                        action='store_true',
+                        help='Ignore destination grid mask')
 
     args = parser.parse_args()
     atm_options = ['JRA55', 'JRA55_runoff', 'CORE2', 'Daitren_runoff']
@@ -217,7 +220,7 @@ def main():
             for method in args.method:
 
                 weights = create_weights(src_grid, dest_grid, args.npes,
-                                         method)
+                                         method, unmasked_dest=args.unmask_dest)
                 if not weights:
                     return 1
                 weights = convert_to_scrip_output(weights)


### PR DESCRIPTION
Added --unmask_dest option to make_remap_weights.py to allow generation of unmasked remapping files.

This is related to https://github.com/COSIMA/access-om2/issues/173 where changes in land mask caused segmentation faults in CICE

This is an example invocation:

```
./make_remap_weights.py /short/x77/nah599/access-om2/input/ /g/data1/ua8/JRA55-do/RYF/v1-3/ /short/x77/nah599/access-om2/input/yatm_1deg/ --atm JRA55 --ocean MOM1 --npes 4 --unmask_dest
```